### PR TITLE
Upped SDK version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 20
-    buildToolsVersion "20.0.0"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         applicationId "tud.seemuh.nfcgate"
         minSdkVersion 19
-        targetSdkVersion 20
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
         ndk {
@@ -29,5 +29,5 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':nfcd')
     compile files('libs/protobuf-java-2.6.1.jar')
-    compile 'com.android.support:support-v4:21.0.3'
+    compile 'com.android.support:support-v4:22.0.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0-rc4'
+        classpath 'com.android.tools.build:gradle:1.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/nfcd/build.gradle
+++ b/nfcd/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "19.1.0"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 19
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
         ndk {
@@ -16,6 +16,11 @@ android {
             abiFilters "armeabi"
         }
     }
+
+    sourceSets.main {
+        jniLibs.srcDir 'src/main/libs'
+    }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -23,9 +28,6 @@ android {
         }
     }
     productFlavors {
-    }
-    sourceSets.main {
-        jniLibs.srcDir 'src/main/libs'
     }
 }
 


### PR DESCRIPTION
See #61.

New basic requirements:
- Gradle 1.1 (should already be installed)
- Android SDK build tools 22.0.1 (install from SDK manager)
- SDK Platform Android 5.1.1 (install from SDK manager)
- Also upped the version of the support libraries, but they should also be installed automatically.

Please make sure you have this installed if compiling isn't working anymore after we merge this.
