### PR TITLE
Update compatible mimetype

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,7 +62,7 @@
                 <action android:name="android.intent.action.SEND" />
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="application/*" />
+                <data android:mimeType="application/*.pcap" />
             </intent-filter>
 
             <meta-data android:name="android.nfc.action.TECH_DISCOVERED"


### PR DESCRIPTION
No idea why initially the app accepts all mimetypes but it is at least annoying to see nfcgate popup as an option for opening files when sharing about any file format.

Would this be an acceptable improvement?