### PR TITLE
Adding Partial Feature of TLS

### DIFF
--- a/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/network/NetworkManager.java
+++ b/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/network/NetworkManager.java
@@ -30,6 +30,7 @@ public class NetworkManager implements ServerConnection.Callback {
     // preference data
     private String mHostname;
     private int mPort, mSessionNumber;
+    private boolean mTLSEnable;
 
     public NetworkManager(MainActivity activity, Callback cb) {
         mActivity = activity;
@@ -45,7 +46,7 @@ public class NetworkManager implements ServerConnection.Callback {
             disconnect();
 
         // establish connection
-        mConnection = new ServerConnection(mHostname, mPort)
+        mConnection = new ServerConnection(mHostname, mPort, mTLSEnable)
                 .setCallback(this)
                 .connect();
 
@@ -115,6 +116,7 @@ public class NetworkManager implements ServerConnection.Callback {
         mHostname = prefs.getString("host", null);
         mPort = Integer.parseInt(prefs.getString("port", "0"));
         mSessionNumber = Integer.parseInt(prefs.getString("session", "0"));
+        mTLSEnable = prefs.getBoolean("tls", false);
     }
 
     private void sendServer(Opcode opcode, byte[] data) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,9 +118,11 @@
     <string name="settings_workaround">Enable Workaround</string>
     <string name="settings_network">Network Settings</string>
     <string name="settings_hostname">Hostname</string>
+    <string name="settings_enable_tls">Enable TLS</string>
     <string name="settings_workaround_summary">Enables the NFC Keep-Alive Workaround</string>
     <string name="settings_hostname_summary">Server Hostname or IP Address</string>
     <string name="settings_hostname_dialog">Enter a valid hostname or IP address</string>
+    <string name="settings_enable_tls_summary">Recommend to encrypt when using public network</string>
     <string name="settings_port">Port</string>
     <string name="settings_port_summary">Server Port</string>
     <string name="settings_port_dialog">Enter a valid port number</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -11,6 +11,14 @@
 
             android:summary="@string/settings_workaround_summary"
             />
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="true"
+
+            android:key="tls"
+            android:summary="@string/settings_enable_tls_summary"
+            android:title="@string/settings_enable_tls" />
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/settings_network"


### PR DESCRIPTION
Partial work for https://github.com/nfcgate/nfcgate/issues/11 
Minimized traffic protection with an option of TLS. This feature can be improved. 

**Residual RISKS**
For now, TLS can be used for passive sniffing prevention. The app will check for CN if is "NFCGate_Server" and give info in Logcat. 
**BUT,** Connection will **NOT** disconnect even if there is a mismatch, which still allows MITM. 
Need help on considering and giving a pop-up to ask user confirm for certificate fingerpint like SSH or disconnect. 

Another implementation is to setup TLS-PSK method instead of using certificate, but neither Android nor Java support this by native. External SDK is required. 

Please also review https://github.com/nfcgate/server/pull/5 in pair. 

REF:
AI Generated Code and Snippets used in commits. 
OpenAI. (2023). ChatGPT (August 3 Version) [GPT-4]. https://chat.openai.com