### PR TITLE
Bump androidx.room:room version to resolve potential build issues

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,8 +116,8 @@ dependencies {
     implementation 'com.github.medyo:android-about-page:1.2.4'
 
     // Room
-    implementation 'androidx.room:room-runtime:2.3.0'
-    annotationProcessor 'androidx.room:room-compiler:2.3.0'
+    implementation 'androidx.room:room-runtime:2.7.2'
+    annotationProcessor 'androidx.room:room-compiler:2.7.2'
 
     // Lifecycle
     implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'


### PR DESCRIPTION
On newer macOS versions, attempting to build the project from scratch causes the following exception to be raised during the build process:

```log
* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':app:compileDebugJavaWithJavac'.
...
Caused by: java.lang.RuntimeException: java.lang.ExceptionInInitializerError
	at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.invocationHelper(Unknown Source)
...
Caused by: java.lang.ExceptionInInitializerError
	at androidx.room.processor.DatabaseProcessor.doProcess(DatabaseProcessor.kt:72)
...
Caused by: java.lang.Exception: No native library is found for os.name=Mac and os.arch=aarch64. path=/org/sqlite/native/Mac/aarch64
	at org.sqlite.SQLiteJDBCLoader.loadSQLiteNativeLibrary(SQLiteJDBCLoader.java:333)
```

Bumping the version of `androidx.room:room` libraries to `2.7.2` resolves the issue, allowing the build to pass, and application to run.