### PR TITLE
Add ability to emulate TB1, TC1, and part of TA1 byte by extracting the full ATS of the original tag

### DIFF
--- a/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/nfc/config/ConfigBuilder.java
+++ b/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/nfc/config/ConfigBuilder.java
@@ -28,6 +28,10 @@ public class ConfigBuilder {
         mOptions.add(option);
     }
 
+    public void addAll(ConfigBuilder builder) {
+        mOptions.addAll(builder.getOptions());
+    }
+
     public List<ConfigOption> getOptions() {
         return mOptions;
     }

--- a/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/nfc/config/OptionType.java
+++ b/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/nfc/config/OptionType.java
@@ -39,10 +39,20 @@ public enum OptionType {
 
     // LISTEN ISO-DEP
 
+        // [2.0] Frame waiting time and start-up frame guard time
+        LI_A_RATS_TB1(0x58),
         // Historical bytes (NCI spec calls this LI_A_HIST_BY)
         LA_HIST_BY(0x59),
         // Higher layer response field
         LB_H_INFO_RSP(0x5A),
+        // Configures (TA1) divisor bits up to specified bitrate
+        // 0x00 -> 106 -> 0b_0_000_0_000
+        // 0x01 -> 212 -> 0b_0_001_0_001
+        // 0x02 -> 424 -> 0b_0_011_0_011
+        // 0x03 -> 848 -> 0b_0_111_0_111
+        LI_A_BIT_RATE(0x5B),
+        // [2.0]: Protocol parameters, NAD/CID support
+        LI_A_RATS_TC1(0x5C)
     ;
 
     // implementation details

--- a/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/nfc/reader/IsoDepReader.java
+++ b/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/nfc/reader/IsoDepReader.java
@@ -2,12 +2,14 @@ package de.tu_darmstadt.seemoo.nfcgate.nfc.reader;
 
 import android.nfc.Tag;
 import android.nfc.tech.IsoDep;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 
 import de.tu_darmstadt.seemoo.nfcgate.nfc.config.ConfigBuilder;
 import de.tu_darmstadt.seemoo.nfcgate.nfc.config.OptionType;
 import de.tu_darmstadt.seemoo.nfcgate.nfc.config.Technologies;
+import de.tu_darmstadt.seemoo.nfcgate.util.ATS;
 
 /**
  * Implements an NFCTagReader using the IsoDep technology
@@ -39,13 +41,45 @@ public class IsoDepReader extends NFCTagReader {
     public ConfigBuilder getConfig() {
         ConfigBuilder builder = mUnderlying.getConfig();
         IsoDep readerIsoDep = (IsoDep) mReader;
-
         // an IsoDep tag can be backed by either NfcA or NfcB technology, build config accordingly
-        if (mUnderlying instanceof NfcAReader)
-            builder.add(OptionType.LA_HIST_BY, readerIsoDep.getHistoricalBytes());
-        else
+        if (mUnderlying instanceof NfcAReader) {
+            // For NFC-A based ISO-DEP, try to get ATS data first
+            ATS ats = getAts();
+            if (ats != null) {
+                Log.i("IsoDepReader", "Adding ATS config");
+                builder.addAll(ats.getConfig());
+            } else {
+                // Fallback to original logic if ATS retrieval fails
+                builder.add(OptionType.LA_HIST_BY, readerIsoDep.getHistoricalBytes());
+            }
+        } else {
             builder.add(OptionType.LB_H_INFO_RSP, readerIsoDep.getHiLayerResponse());
+        }
 
         return builder;
+    }
+
+    /**
+     * Attempts to get the ATS (Answer To Select) response by issuing a RATS command manually
+     * 
+     * @return parsed ATS response object, or null if RATS command fails or not possible to execute
+     */
+    public ATS getAts() {
+        try {
+            this.close();
+            this.mUnderlying.connect();
+            // RATS format: E0 FSDI|CID (where FSDI=Frame Size and CID=Card Identifier)
+            // Using FSDI=8 (256 bytes) and CID=0
+            byte[] ratsCommand = new byte[] { (byte) 0xE0, (byte) 0x80 };
+            byte[] atsResponse = this.mUnderlying.transceive(ratsCommand);
+            return ATS.parse(atsResponse);
+        } catch (Exception e) {
+            Log.e("IsoDepReader", "Could not get full ATS due to " + Log.getStackTraceString(e));
+            // If something fails, return null
+            return null;
+        } finally {
+            this.mUnderlying.close();
+            this.connect();
+        }
     }
 }

--- a/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/nfc/reader/IsoDepReader.java
+++ b/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/nfc/reader/IsoDepReader.java
@@ -44,10 +44,9 @@ public class IsoDepReader extends NFCTagReader {
         // an IsoDep tag can be backed by either NfcA or NfcB technology, build config accordingly
         if (mUnderlying instanceof NfcAReader) {
             // For NFC-A based ISO-DEP, try to get ATS data first
-            ATS ats = getAts();
-            if (ats != null) {
-                Log.i("IsoDepReader", "Adding ATS config");
-                builder.addAll(ats.getConfig());
+            ConfigBuilder configFromAts = getConfigFromAts();
+            if (configFromAts != null) {
+                builder.addAll(configFromAts);
             } else {
                 // Fallback to original logic if ATS retrieval fails
                 builder.add(OptionType.LA_HIST_BY, readerIsoDep.getHistoricalBytes());
@@ -61,10 +60,11 @@ public class IsoDepReader extends NFCTagReader {
 
     /**
      * Attempts to get the ATS (Answer To Select) response by issuing a RATS command manually
+     * and generating the NCI configuration matching to the extracted data
      * 
      * @return parsed ATS response object, or null if RATS command fails or not possible to execute
      */
-    public ATS getAts() {
+    public ConfigBuilder getConfigFromAts() {
         try {
             this.close();
             this.mUnderlying.connect();

--- a/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/util/ATS.java
+++ b/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/util/ATS.java
@@ -19,38 +19,19 @@ import de.tu_darmstadt.seemoo.nfcgate.nfc.config.OptionType;
  * - Historical bytes (optional): Application-specific data
  */
 public final class ATS {
-    private final byte tl;
-    private final byte t0;
-    @Nullable
-    private final Byte ta;
-    @Nullable
-    private final Byte tb;
-    @Nullable
-    private final Byte tc;
-    private final byte[] historicalBytes;
-
     // T0 format byte bit masks
     private static final int TA_PRESENT = 0x10;   // TA(1) present (bit 5)
     private static final int TB_PRESENT = 0x20;   // TB(1) present (bit 6)
     private static final int TC_PRESENT = 0x40;   // TC(1) present (bit 7)
 
-    private ATS(byte tl, byte t0, @Nullable Byte ta, @Nullable Byte tb, @Nullable Byte tc, byte[] historicalBytes) {
-        this.tl = tl;
-        this.t0 = t0;
-        this.ta = ta;
-        this.tb = tb;
-        this.tc = tc;
-        this.historicalBytes = historicalBytes;
-    }
-
     /**
-     * Parse ATS bytes into an ATS object.
+     * Parse ATS bytes into NCI configuration
      *
      * @param atsBytes The complete ATS response bytes
-     * @return Parsed ATS object
+     * @return ConfigBuilder containing NCI configuration options that were extracted from the ATS data
      * @throws IllegalArgumentException if the ATS data is invalid
      */
-    public static ATS parse(byte[] atsBytes) {
+    public static ConfigBuilder parse(byte[] atsBytes) {
         if (atsBytes == null || atsBytes.length < 2) {
             throw new IllegalArgumentException("ATS must be at least 2 bytes (TL + T0)");
         }
@@ -60,70 +41,49 @@ public final class ATS {
             throw new IllegalArgumentException("ATS length mismatch: TL=" + tl + ", actual=" + atsBytes.length);
         }
 
+        ConfigBuilder builder = new ConfigBuilder();
+
         byte t0 = atsBytes[1];
         int offset = 2;
 
         // Parse optional interface bytes
-        Byte ta = null, tb = null, tc = null;
 
         if ((t0 & TA_PRESENT) != 0) {
             if (offset >= atsBytes.length) {
                 throw new IllegalArgumentException("ATS truncated: TA(1) expected but not present");
             }
-            ta = atsBytes[offset++];
+            byte ta = atsBytes[offset++];
+            // Set closest DR/DS bit config of TA(1) if present
+            builder.add(OptionType.LI_A_BIT_RATE, new byte[] { getClosestNciBitRateConfig(ta) });
         }
 
         if ((t0 & TB_PRESENT) != 0) {
             if (offset >= atsBytes.length) {
                 throw new IllegalArgumentException("ATS truncated: TB(1) expected but not present");
             }
-            tb = atsBytes[offset++];
+            byte tb = atsBytes[offset++];
+            // Add TB(1) if present - contains FWI and SFGI
+            builder.add(OptionType.LI_A_RATS_TB1, new byte[] { tb });
         }
 
         if ((t0 & TC_PRESENT) != 0) {
             if (offset >= atsBytes.length) {
                 throw new IllegalArgumentException("ATS truncated: TC(1) expected but not present");
             }
-            tc = atsBytes[offset++];
+            byte tc = atsBytes[offset++];
+            // Add TC(1) if present - contains CID/NAD support info
+            builder.add(OptionType.LI_A_RATS_TC1, new byte[] { tc });
         }
 
         // Extract historical bytes (remaining bytes)
         byte[] historical = new byte[atsBytes.length - offset - 1];
         if (historical.length > 0) {
             System.arraycopy(atsBytes, offset, historical, 0, historical.length);
-        }
+            // Add historical bytes if present
+            if (historical.length != 0) {
+                builder.add(OptionType.LA_HIST_BY, historical);
+            }
 
-        return new ATS((byte) tl, t0, ta, tb, tc, historical);
-    }
-
-    /**
-     * Get the NCI configuration from the ATS data.
-     * Extracts relevant configuration options that can be used for card emulation.
-     *
-     * @return ConfigBuilder containing NCI configuration options that were extracted from the ATS data
-     */
-    @NonNull
-    public ConfigBuilder getConfig() {
-        ConfigBuilder builder = new ConfigBuilder();
-
-        // Set closest DR/DS bit config of TA(1) if present
-        if (ta != null) {
-            builder.add(OptionType.LI_A_BIT_RATE, new byte[] { getClosestNciBitRateConfig(ta) });
-        }
-
-        // Add TB(1) if present - contains FWI and SFGI
-        if (tb != null) {
-            builder.add(OptionType.LI_A_RATS_TB1, new byte[] { tb });
-        }
-
-        // Add TC(1) if present - contains CID/NAD support info
-        if (tc != null) {
-            builder.add(OptionType.LI_A_RATS_TC1, new byte[] { tc });
-        }
-
-        // Add historical bytes if present
-        if (historicalBytes.length != 0) {
-            builder.add(OptionType.LA_HIST_BY, historicalBytes);
         }
 
         return builder;

--- a/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/util/ATS.java
+++ b/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/util/ATS.java
@@ -1,0 +1,172 @@
+package de.tu_darmstadt.seemoo.nfcgate.util;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import de.tu_darmstadt.seemoo.nfcgate.nfc.config.ConfigBuilder;
+import de.tu_darmstadt.seemoo.nfcgate.nfc.config.OptionType;
+
+
+/**
+ * Answer To Select (ATS) parser for ISO14443-4 Type A cards.
+ * The ATS contains configuration parameters returned by a card in response to a RATS command.
+ * According to ISO14443-4, the ATS structure is:
+ * - TL (1 byte): Length of ATS
+ * - T0 (1 byte): Format byte (FSCI, FWI, presence of optional TA/TB/TC bytes)
+ * - TA(1) (optional): supported divisors
+ * - TB(1) (optional): FWI and SFGI values
+ * - TC(1) (optional): CID/NAD support
+ * - Historical bytes (optional): Application-specific data
+ */
+public final class ATS {
+    private final byte tl;
+    private final byte t0;
+    @Nullable
+    private final Byte ta;
+    @Nullable
+    private final Byte tb;
+    @Nullable
+    private final Byte tc;
+    private final byte[] historicalBytes;
+
+    // T0 format byte bit masks
+    private static final int TA_PRESENT = 0x10;   // TA(1) present (bit 5)
+    private static final int TB_PRESENT = 0x20;   // TB(1) present (bit 6)
+    private static final int TC_PRESENT = 0x40;   // TC(1) present (bit 7)
+
+    private ATS(byte tl, byte t0, @Nullable Byte ta, @Nullable Byte tb, @Nullable Byte tc, byte[] historicalBytes) {
+        this.tl = tl;
+        this.t0 = t0;
+        this.ta = ta;
+        this.tb = tb;
+        this.tc = tc;
+        this.historicalBytes = historicalBytes;
+    }
+
+    /**
+     * Parse ATS bytes into an ATS object.
+     *
+     * @param atsBytes The complete ATS response bytes
+     * @return Parsed ATS object
+     * @throws IllegalArgumentException if the ATS data is invalid
+     */
+    public static ATS parse(byte[] atsBytes) {
+        if (atsBytes == null || atsBytes.length < 2) {
+            throw new IllegalArgumentException("ATS must be at least 2 bytes (TL + T0)");
+        }
+
+        int tl = atsBytes[0] & 0xFF;
+        if (tl != atsBytes.length - 1) {
+            throw new IllegalArgumentException("ATS length mismatch: TL=" + tl + ", actual=" + atsBytes.length);
+        }
+
+        byte t0 = atsBytes[1];
+        int offset = 2;
+
+        // Parse optional interface bytes
+        Byte ta = null, tb = null, tc = null;
+
+        if ((t0 & TA_PRESENT) != 0) {
+            if (offset >= atsBytes.length) {
+                throw new IllegalArgumentException("ATS truncated: TA(1) expected but not present");
+            }
+            ta = atsBytes[offset++];
+        }
+
+        if ((t0 & TB_PRESENT) != 0) {
+            if (offset >= atsBytes.length) {
+                throw new IllegalArgumentException("ATS truncated: TB(1) expected but not present");
+            }
+            tb = atsBytes[offset++];
+        }
+
+        if ((t0 & TC_PRESENT) != 0) {
+            if (offset >= atsBytes.length) {
+                throw new IllegalArgumentException("ATS truncated: TC(1) expected but not present");
+            }
+            tc = atsBytes[offset++];
+        }
+
+        // Extract historical bytes (remaining bytes)
+        byte[] historical = new byte[atsBytes.length - offset - 1];
+        if (historical.length > 0) {
+            System.arraycopy(atsBytes, offset, historical, 0, historical.length);
+        }
+
+        return new ATS((byte) tl, t0, ta, tb, tc, historical);
+    }
+
+    /**
+     * Get the NCI configuration from the ATS data.
+     * Extracts relevant configuration options that can be used for card emulation.
+     *
+     * @return ConfigBuilder containing NCI configuration options that were extracted from the ATS data
+     */
+    @NonNull
+    public ConfigBuilder getConfig() {
+        ConfigBuilder builder = new ConfigBuilder();
+
+        // Set closest DR/DS bit config of TA(1) if present
+        if (ta != null) {
+            builder.add(OptionType.LI_A_BIT_RATE, new byte[] { getClosestNciBitRateConfig(ta) });
+        }
+
+        // Add TB(1) if present - contains FWI and SFGI
+        if (tb != null) {
+            builder.add(OptionType.LI_A_RATS_TB1, new byte[] { tb });
+        }
+
+        // Add TC(1) if present - contains CID/NAD support info
+        if (tc != null) {
+            builder.add(OptionType.LI_A_RATS_TC1, new byte[] { tc });
+        }
+
+        // Add historical bytes if present
+        if (historicalBytes.length != 0) {
+            builder.add(OptionType.LA_HIST_BY, historicalBytes);
+        }
+
+        return builder;
+    }
+
+    /**
+     * Get the closest NCI bit rate configuration that doesn't exceed the original TA value.
+     *
+     * @param taValue The original TA(1) byte containing divisor values
+     * @return The closest NCI bit rate configuration byte
+     */
+    private static byte getClosestNciBitRateConfig(byte taValue) {
+        // NCI bit rate configurations:
+        // 0x00 -> 106 kbps -> 0b_0_000_0_000
+        // 0x01 -> 212 kbps -> 0b_0_001_0_001  
+        // 0x02 -> 424 kbps -> 0b_0_011_0_011
+        // 0x03 -> 848 kbps -> 0b_0_111_0_111
+
+        int ta = taValue & 0xFF;
+        // Extract divisor values from TA(1)
+        // Bits 7-4: Card to reader divisor (DSI)
+        // Bits 3-0: Reader to card divisor (DRI)
+        int dsi = (ta >> 4) & 0x0F;  // Card to reader
+        int dri = ta & 0x0F;         // Reader to card
+
+        // Find the highest NCI config that doesn't exceed either direction
+        byte maxConfig = 0x00;  // Start with 106 kbps
+
+        // Check if 212 kbps (0x01) is supported
+        if ((dsi & 0x01) != 0 && (dri & 0x01) != 0) {
+            maxConfig = 0x01;
+        }
+
+        // Check if 424 kbps (0x02) is supported  
+        if ((dsi & 0x03) == 0x03 && (dri & 0x03) == 0x03) {
+            maxConfig = 0x02;
+        }
+
+        // Check if 848 kbps (0x03) is supported
+        if ((dsi & 0x07) == 0x07 && (dri & 0x07) == 0x07) {
+            maxConfig = 0x03;
+        }
+
+        return maxConfig;
+    }
+}


### PR DESCRIPTION
### Feature
This PR improves functionality of ATS emulation by extracting additional information from the original tag and using the available NCI properties in order to try to adhere more closely to the source ATS.

Extraction of ATS is implemented by downgrading to NFC-A level and re-issuing the RATS command manually, thus getting the raw response.

Extracted TA(1), TB(1) and TC(1) bytes are then configured using the following NCI properties:
- TA(1) - we choose between 4 DR/DS bit configurations by setting the LI_A_BIT_RATE property.
- TB(1) - LI_A_RATS_TB1;
- TC(1) - LI_A_RATS_TC1.

That leaves some aspects that are still out of our control:
- FSC config in byte T0;
- Same DR/DS bit in TA(1);
- Non-symmetric and non-incremental DR/DS configurations in TA(1);
- CID bit in TC(1).


### Potential improvements
Some properties, such as FSC, can be configured through proprietary tags (e.g., A083 for NXP chips). However, supporting this would require maintaining a tag/feature compatibility list based on the detected chipset.


### Testing
I've tested the current implementation on a Google Pixel 7 phone with a bunch of EMV and DESFire tags.
Tags that have FSC=0x08, same DR/DS, and preset TC(1) can be emulated exactly. For other tags, there will be mismatches as described above.

No issues were encountered during my trials, but with limited amount of targets I'm able to test with, I cannot guarantee that this will be the case for all devices.


### Considerations
There are a couple of considerations to take into account before this change can be accepted:
- LI_A_RATS_TC1 is not supported on non-NCI2.0 chips;
- LI_A_RATS_TB1 may not have the intended effect on non-NCI2.0 chips;
- Some vendors do not guarantee full support for all configuration options (I.E. NXP has a table of "supported/partial/unsupported" options, although in their case everything should be supported here);
- During the ATS extraction, with downgrade to NfcA and later re-upgrade to IsoDep, [the chip should reset the tag when switching tag interface, thus avoiding any state inconsistencies](https://cs.android.com/android/platform/superproject/main/+/main:packages/modules/Nfc/NfcNci/nci/jni/NativeNfcTag.cpp;drc=61197364367c9e404c7da6900658f1b16c42d0da;l=542), but it is not known to me if this is the case for all chips and tags on all Android versions.

