### PR TITLE
Handle incoming ACTION_NDEF_DISCOVERED intents

### DIFF
--- a/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/gui/MainActivity.java
+++ b/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/gui/MainActivity.java
@@ -127,8 +127,9 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onNewIntent(Intent intent) {
         // tech discovered is triggered by XML, tag discovered by foreground dispatch
-        if (NfcAdapter.ACTION_TECH_DISCOVERED.equals(intent.getAction()) ||
-                NfcAdapter.ACTION_TAG_DISCOVERED.equals(intent.getAction()))
+        if (NfcAdapter.ACTION_TECH_DISCOVERED.equals(intent.getAction())
+                || NfcAdapter.ACTION_TAG_DISCOVERED.equals(intent.getAction())
+                || NfcAdapter.ACTION_NDEF_DISCOVERED.equals(intent.getAction()))
             mNfc.onTagDiscovered(intent.getParcelableExtra(NfcAdapter.EXTRA_TAG));
         else if (Intent.ACTION_SEND.equals(intent.getAction()))
             importPcap(intent.getParcelableExtra(Intent.EXTRA_STREAM));


### PR DESCRIPTION
When testing the "Clone" functionality with some EMV cards on a Google Pixel 7 running Android 15, I noticed that the application was unable to read them, attempting to re-read the tag in an endless loop accompanied by constant buzzing.

Logcat was reporting the following log message for each read attempt:
```log
Background activity launch blocked! [callingPackage: de.tu_darmstadt.seemoo.nfcgate; callingPackageTargetSdk: 35; callingUid: 10354; callingPid: -1; appSwitchState: 2; callingUidHasAnyVisibleWindow: true; callingUidProcState: TOP; isCallingUidPersistentSystemProcess: false; forcedBalByPiSender: BSP.NONE; intent: Intent { act=android.nfc.action.NDEF_DISCOVERED typ=text/plain cmp=de.tu_darmstadt.seemoo.nfcgate/.gui.MainActivity (has extras) }; callerApp: null; balAllowedByPiCreator: BSP.NONE; balAllowedByPiCreatorWithHardening: BSP.NONE; resultIfPiCreatorAllowsBal: BAL_ALLOW_VISIBLE_WINDOW; callerStartMode: MODE_BACKGROUND_ACTIVITY_START_SYSTEM_DEFINED; hasRealCaller: true; isCallForResult: false; isPendingIntent: true; autoOptInReason: null; realCallingPackage: com.android.nfc; realCallingPackageTargetSdk: 35; realCallingUid: 1027; realCallingPid: 3917; realCallingUidHasAnyVisibleWindow: false; realCallingUidProcState: PERSISTENT; isRealCallingUidPersistentSystemProcess: true; originatingPendingIntent: PendingIntentRecord{23e8293 de.tu_darmstadt.seemoo.nfcgate startActivity}; realCallerApp: null; balAllowedByPiSender: BSP.ALLOW_FGS; resultIfPiSenderAllowsBal: BAL_BLOCK; realCallerStartMode: MODE_BACKGROUND_ACTIVITY_START_SYSTEM_DEFINED; balImproveRealCallerVisibilityCheck: true; balRequireOptInByPendingIntentCreator: true; balRequireOptInSameUid: false; balRespectAppSwitchStateWhenCheckBoundByForegroundUid: true; balDontBringExistingBackgroundTaskStackToFg: true]
```

Which indicated that system was attempting to deliver `android.nfc.action.NDEF_DISCOVERED`, which was not handled in `onNewIntent`.

[According to the official Android documentation](https://developer.android.com/reference/android/nfc/NfcAdapter#enableForegroundDispatch(android.app.Activity,%20android.app.PendingIntent,%20android.content.IntentFilter[],%20java.lang.String[][])), `enableForegroundDispatch()` is called in a way that should only cause `ACTION_TAG_DISCOVERED` to trigger.

I am not sure exactly as to what's the real culprit here, so as a quick way of resolving that issue, I've added handling for `android.nfc.action.NDEF_DISCOVERED` in the `onNewIntent` method.

With this change, my device is now able to run "Clone" mode on EMV cards with embedded NDEF messages.