### PR TITLE
Fix NPE in MapInfo

### DIFF
--- a/nfcd/src/main/jni/src/helper/MapInfo.cpp
+++ b/nfcd/src/main/jni/src/helper/MapInfo.cpp
@@ -3,6 +3,8 @@
 
 #include <fstream>
 #include <regex>
+#include <cstring>
+#include <cstdio>
 
 #include <link.h>
 
@@ -13,8 +15,21 @@ bool MapInfo::create() {
     int rv = dl_iterate_phdr([] (struct dl_phdr_info *info, size_t, void *user_data) {
         auto *instance = (MapInfo *)user_data;
 
+        // Skip entries with null names to prevent crashes
+        if (!info->dlpi_name)
+            return 0;
+        
+        // Use memory address as unique identifier for entries with empty names
+        std::string libName;
+        if (strlen(info->dlpi_name) == 0) {
+            char addrStr[32];
+            snprintf(addrStr, sizeof(addrStr), "0x%lx", (unsigned long)info->dlpi_addr);
+            libName = addrStr;
+        } else
+            libName = info->dlpi_name;
+
         // map library name to new library entry with base address
-        auto &entry = *instance->mLibraryData.try_emplace(info->dlpi_name, info->dlpi_name).first;
+        auto &entry = *instance->mLibraryData.try_emplace(libName, libName).first;
         for (size_t i = 0; i < info->dlpi_phnum; i++) {
             // set base address to relocation + PT_LOAD vaddr if not already set
             // PT_LOAD headers are sorted in ascending vaddr order so using the first is correct

--- a/nfcd/src/main/jni/src/helper/MapInfo.cpp
+++ b/nfcd/src/main/jni/src/helper/MapInfo.cpp
@@ -20,13 +20,7 @@ bool MapInfo::create() {
             return 0;
         
         // Use memory address as unique identifier for entries with empty names
-        std::string libName;
-        if (strlen(info->dlpi_name) == 0) {
-            char addrStr[32];
-            snprintf(addrStr, sizeof(addrStr), "0x%lx", (unsigned long)info->dlpi_addr);
-            libName = addrStr;
-        } else
-            libName = info->dlpi_name;
+        auto libName = info->dlpi_name[0] ? info->dlpi_name : "<" + std::to_string(info->dlpi_addr) + ">";
 
         // map library name to new library entry with base address
         auto &entry = *instance->mLibraryData.try_emplace(libName, libName).first;


### PR DESCRIPTION
## Summary
Fix null pointer exception in MapInfo library iteration and prevent key collisions that can cause crashes and data loss during native library discovery.

## Problem
The `dl_iterate_phdr` callback can receive `dl_phdr_info` entries with null `dlpi_name` pointers, which caused crashes when passed to `strlen()` and map operations.

Additionally, multiple libraries with empty names would all map to the same key, causing later entries to overwrite earlier ones and losing library information.

I encountered this problem while testing on LineageOS 7.1.2 on Sony Xperia Z5 Compact.

## Solution
- Add null check for `info->dlpi_name` to skip entries with null names
- Use `dlpi_addr` (memory address) as unique identifier for entries with empty names
- Prevent crashes during library iteration while preserving all library data
- Ensure each library gets a unique map key to prevent data loss

## Changes
- Added null pointer safety in `MapInfo.cpp:17-29`
- Use memory address format (e.g., `0x7f8b12345000`) for unnamed libraries
- Added `#include <cstdio>` for `snprintf` functionality
- Preserves existing library discovery logic while fixing key collisions

## Test Results
Eliminates crashes during native hook initialization on devices with problematic library entries and prevents loss of library information due to key collisions.

Please also see #227, where this change originated from.