### PR TITLE
Add APDU command type display in relay mode

### DIFF
--- a/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/gui/log/SessionLogEntryFragment.java
+++ b/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/gui/log/SessionLogEntryFragment.java
@@ -30,7 +30,9 @@ import de.tu_darmstadt.seemoo.nfcgate.db.model.SessionLogEntryViewModel;
 import de.tu_darmstadt.seemoo.nfcgate.db.model.SessionLogEntryViewModelFactory;
 import de.tu_darmstadt.seemoo.nfcgate.gui.component.CustomArrayAdapter;
 import de.tu_darmstadt.seemoo.nfcgate.nfc.config.ConfigBuilder;
+import de.tu_darmstadt.seemoo.nfcgate.util.ApduClassifier;
 import de.tu_darmstadt.seemoo.nfcgate.util.NfcComm;
+import de.tu_darmstadt.seemoo.nfcgate.util.Utils;
 
 import static de.tu_darmstadt.seemoo.nfcgate.util.Utils.bytesToHexDump;
 
@@ -162,6 +164,8 @@ public class SessionLogEntryFragment extends Fragment {
     }
 
     private static class SessionLogEntryListAdapter extends CustomArrayAdapter<NfcComm> {
+        private String mPrevCommandType = "";
+
         SessionLogEntryListAdapter(@NonNull Context context, int resource) {
             super(context, resource);
         }
@@ -183,6 +187,25 @@ public class SessionLogEntryFragment extends Fragment {
 
             // set image indicating card or reader
             v.<ImageView>findViewById(R.id.type).setImageResource(byCard(comm.isCard()));
+
+            // classify APDU command type
+            String hexData = Utils.bytesToHex(comm.getData());
+            String commandType = ApduClassifier.classifyApdu(hexData, comm.isCard(), mPrevCommandType);
+
+            // update previous command type if this is a command (not a response)
+            if (!comm.isCard() && !commandType.equals("UNKNOWN")) {
+                mPrevCommandType = commandType;
+            }
+
+            // set command type
+            TextView commandTypeView = v.findViewById(R.id.command_type);
+            if (!commandType.equals("UNKNOWN") && !commandType.isEmpty()) {
+                commandTypeView.setText(commandType);
+                commandTypeView.setVisibility(View.VISIBLE);
+            } else {
+                commandTypeView.setVisibility(View.GONE);
+            }
+
             // set content to either config stream or binary content
             v.<TextView>findViewById(R.id.data).setText(byInitial(comm.isInitial(), comm.getData()));
             // set timestamp

--- a/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/util/ApduClassifier.java
+++ b/app/src/main/java/de/tu_darmstadt/seemoo/nfcgate/util/ApduClassifier.java
@@ -1,0 +1,180 @@
+package de.tu_darmstadt.seemoo.nfcgate.util;
+
+/**
+ * Utility class for classifying APDU command types based on hex data
+ * Ported from Python parsing logic
+ */
+public class ApduClassifier {
+
+    /**
+     * Classifies an APDU hex string into a command type
+     * @param hexData The hex string of the APDU (without spaces)
+     * @param isCard True if data is from card (response), false if from reader (command)
+     * @param prevCommandType The previous command type for context
+     * @return The classified command type string
+     */
+    public static String classifyApdu(String hexData, boolean isCard, String prevCommandType) {
+        if (hexData == null || hexData.isEmpty()) {
+            return "UNKNOWN";
+        }
+
+        // Convert to lowercase for easier matching
+        String data = hexData.toLowerCase();
+
+        // If it's a response (from card)
+        if (isCard) {
+            return classifyResponse(data, prevCommandType);
+        }
+        // If it's a command (from reader)
+        else {
+            return classifyCommand(data);
+        }
+    }
+
+    /**
+     * Classifies a command APDU
+     */
+    private static String classifyCommand(String data) {
+        // Status only (CONTROL FLOW response)
+        if (data.equals("9000") || (data.length() == 4 && data.endsWith("9000"))) {
+            return "CONTROL FLOW response";
+        }
+
+        // Need at least 6 characters for command classification
+        if (data.length() < 6) {
+            return "UNKNOWN";
+        }
+
+        // SELECT
+        if (data.startsWith("00a40400")) {
+            return "SELECT";
+        }
+
+        // SPAKE2+ REQUEST
+        if (data.startsWith("80300000")) {
+            return "SPAKE2+ REQUEST";
+        }
+
+        // SPAKE2+ VERIFY
+        if (data.startsWith("80320000")) {
+            return "SPAKE2+ VERIFY";
+        }
+
+        // AUTH0 and AUTH1
+        String cla = data.substring(0, 2);
+        String ins = data.substring(2, 4);
+
+        if (cla.equals("80") && ins.equals("80")) {
+            return "AUTH0";
+        }
+        if (cla.equals("80") && ins.equals("81")) {
+            return "AUTH1";
+        }
+
+        // WRITE DATA
+        if (data.startsWith("84d4")) {
+            return "WRITE DATA";
+        }
+
+        // GET DATA
+        if (data.startsWith("84ca")) {
+            return "GET DATA";
+        }
+
+        // GET RESPONSE
+        if (data.startsWith("84c0")) {
+            return "GET RESPONSE";
+        }
+
+        // EXCHANGE
+        if (data.startsWith("84c9")) {
+            return "EXCHANGE";
+        }
+
+        // CONTROL FLOW
+        if (data.startsWith("803c")) {
+            return "CONTROL FLOW";
+        }
+
+        return "UNKNOWN";
+    }
+
+    /**
+     * Classifies a response APDU
+     */
+    private static String classifyResponse(String data, String prevCommandType) {
+        // Status only (CONTROL FLOW response)
+        if (data.equals("9000") || (data.length() == 4 && data.endsWith("9000"))) {
+            return "CONTROL FLOW response";
+        }
+
+        // Check if it ends with 9000 or 61xx (success status)
+        boolean hasSuccessStatus = data.endsWith("9000") ||
+                                   (data.length() >= 4 && data.substring(data.length() - 4, data.length() - 2).equals("61"));
+
+        if (hasSuccessStatus) {
+            // SELECT response
+            if (data.startsWith("5a") || data.startsWith("5c") || data.startsWith("d4")) {
+                return "SELECT response";
+            }
+
+            // SPAKE2+ REQUEST response (50h, 5Fh)
+            if (data.startsWith("50") || data.startsWith("5f")) {
+                return "SPAKE2+ REQUEST response";
+            }
+
+            // SPAKE2+ VERIFY response (58h)
+            if (data.startsWith("58")) {
+                return "SPAKE2+ VERIFY response";
+            }
+
+            // AUTH0 response (86h or 9Dh tags)
+            if (data.startsWith("86") || data.startsWith("9d")) {
+                return "AUTH0 response";
+            }
+
+            // AUTH1 response (9Eh tag)
+            if (data.startsWith("9e")) {
+                return "AUTH1 response";
+            }
+
+            // Use previous command type for context
+            if (prevCommandType != null && !prevCommandType.isEmpty()) {
+                if (prevCommandType.contains("AUTH0")) {
+                    return "AUTH0 response";
+                } else if (prevCommandType.contains("AUTH1")) {
+                    return "AUTH1 response";
+                } else if (prevCommandType.contains("WRITE DATA")) {
+                    return "WRITE DATA response";
+                } else if (prevCommandType.contains("SPAKE2+ REQUEST")) {
+                    return "SPAKE2+ REQUEST response";
+                } else if (prevCommandType.contains("SPAKE2+ VERIFY")) {
+                    return "SPAKE2+ VERIFY response";
+                } else if (prevCommandType.contains("GET RESPONSE")) {
+                    return "GET RESPONSE response";
+                } else if (prevCommandType.contains("GET DATA")) {
+                    return "GET DATA response";
+                } else if (prevCommandType.contains("EXCHANGE")) {
+                    return "EXCHANGE response";
+                } else if (prevCommandType.contains("CONTROL FLOW")) {
+                    return "CONTROL FLOW response";
+                }
+            }
+
+            return "UNKNOWN response";
+        }
+
+        return "UNKNOWN";
+    }
+
+    /**
+     * Gets a shortened version of the command type for display
+     */
+    public static String getShortCommandType(String commandType) {
+        if (commandType == null || commandType.equals("UNKNOWN")) {
+            return "";
+        }
+        // Remove " response" suffix for cleaner display
+        return commandType.replace(" response", "");
+    }
+}

--- a/app/src/main/res/layout/list_log_entry.xml
+++ b/app/src/main/res/layout/list_log_entry.xml
@@ -13,12 +13,25 @@
         android:layout_height="32dp"
         />
     <TextView
-        android:id="@+id/data"
+        android:id="@+id/command_type"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="10dp"
 
         android:layout_alignParentTop="true"
+        android:layout_toRightOf="@+id/type"
+
+        style="@style/Hexdump"
+        android:textColor="#FFA726"
+        android:textStyle="bold"
+        />
+    <TextView
+        android:id="@+id/data"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+
+        android:layout_below="@+id/command_type"
         android:layout_toRightOf="@+id/type"
 
         style="@style/Hexdump"


### PR DESCRIPTION
This commit adds command type classification and display for NFC packets in relay mode, making it easier to identify different APDU commands at a glance. The implementation is based on the Python parsing logic provided.

Changes:
- Added ApduClassifier utility class to classify APDU commands (SELECT, AUTH0/AUTH1, SPAKE2+, etc.)
- Updated list_log_entry.xml layout to include command type TextView
- Modified SessionLogEntryFragment to display command type above packet data
- Command types are shown in bold orange text for better visibility